### PR TITLE
[WIP] \snippet proposal

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ default: all
 .PHONY: clean
 
 all:
-	pdflatex main
-	pdflatex main
+	pdflatex --shell-escape main
+	pdflatex --shell-escape main
 	mv main.pdf "$(PDFNAME)"
 
 clean:

--- a/content/basics.tex
+++ b/content/basics.tex
@@ -1,7 +1,7 @@
 \section{Basics}
 
 \subsection{C++ template}
-\lstinputlisting{source/template.cpp}
+\snippet{source/template.cpp}
 
 \subsection{Compiling with sanitize options}
 \begin{lstlisting}[breakatwhitespace=true]

--- a/content/maths.tex
+++ b/content/maths.tex
@@ -144,7 +144,7 @@ Requires \verb|pollard_rho(ll)|
 
 Solves $ax + by = gcd(a, b)$ \\
 \verb|auto [x, y, g] = egcd(l, n[i]);|
-\lstinputlisting{source/egcd.cpp}
+\snippet{source/egcd.cpp}
 
 
 \subsection{Diophantine Linear Equations}

--- a/main.tex
+++ b/main.tex
@@ -135,6 +135,8 @@
 \fontencoding{U}\fontfamily{futs}\selectfont\char#1}}
 \newcommand*{\warning}{\TakeFourierOrnament{66}}
 
+\newcommand{\snippet}[1]{\input|"./utils/gen_snippet.py #1"}
+
 \begin{document}
 \begin{multicols*}{3}
 

--- a/source/common.h
+++ b/source/common.h
@@ -1,4 +1,5 @@
-// keep-line
+#pragma once
+
 #include <bits/stdc++.h>
 using namespace std;
 
@@ -9,7 +10,3 @@ using ll = long long;
 using ld = long double;
 using vi = vector<int>;
 using vll = vector<ll>;
-
-int main() {
-	cin.tie(0)->sync_with_stdio(false);
-}

--- a/source/egcd.cpp
+++ b/source/egcd.cpp
@@ -1,4 +1,3 @@
-#pragma once
 #include "common.h"
 
 array<ll,3> egcd(ll a, ll b) {

--- a/source/egcd.cpp
+++ b/source/egcd.cpp
@@ -1,3 +1,6 @@
+#pragma once
+#include "common.h"
+
 array<ll,3> egcd(ll a, ll b) {
 	ll x = 1, y = 0;
 	ll x1 = 0, y1 = 1, a1 = a, b1 = b;

--- a/utils/gen_snippet.py
+++ b/utils/gen_snippet.py
@@ -6,11 +6,7 @@
 - Trim lines and remove empty ones
 """
 
-import sys
-
-def usage(argv0):
-    print(f"Usage: {argv0} <input_file_name.cpp>")
-    sys.exit(1)
+import argparse
 
 def parse_file(source_name):
     with open(source_name) as fin:
@@ -53,9 +49,8 @@ def generate(source_name):
     print("\\end{lstlisting}")
 
 if __name__ == '__main__':
-    if len(sys.argv) < 2:
-        usage()
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_file_name", help="The name of the input file.")
+    args = parser.parse_args()
 
-    source_name = sys.argv[1]
-    generate(source_name)
-
+    generate(args.input_file_name)

--- a/utils/gen_snippet.py
+++ b/utils/gen_snippet.py
@@ -1,0 +1,61 @@
+#!/usr/bin/env python3
+
+"""
+- Remove includes
+- Remove pragmas
+- Trim lines and remove empty ones
+"""
+
+import sys
+
+def usage(argv0):
+    print(f"Usage: {argv0} <input_file_name.cpp>")
+    sys.exit(1)
+
+def parse_file(source_name):
+    with open(source_name) as fin:
+        lines = [x.rstrip() for x in fin.readlines()]
+
+    # Remove all includes and pragmas, unless guarded by "// keep-line"
+    out_lines = []
+    keep = False
+    for line in lines:
+        # Allow for spaces
+        if line.replace(' ','').startswith('//keep-line'):
+            keep = True
+        else:
+            maybe_remove = False
+            if line.replace(' ','').startswith('#include'):
+                maybe_remove = True
+            if line.replace(' ','').startswith('#pragma'):
+                maybe_remove = True
+
+            if keep or not maybe_remove:
+                out_lines.append(line)
+            keep = False
+
+    lines = out_lines
+
+    # Remove empty lines at start and end of file
+    while len(lines) > 0 and len(lines[0].strip()) == 0:
+        lines.pop(0)
+    while len(lines) > 0 and len(lines[-1].strip()) == 0:
+        lines.pop()
+
+    return lines
+
+def generate(source_name):
+    lines = parse_file(source_name)
+
+    print("\\begin{lstlisting}")
+    for line in lines:
+        print(line)
+    print("\\end{lstlisting}")
+
+if __name__ == '__main__':
+    if len(sys.argv) < 2:
+        usage()
+
+    source_name = sys.argv[1]
+    generate(source_name)
+


### PR DESCRIPTION
As I see it, there are currently some problems with how the booklet is organized:
- Code snippets don't include the common definitions (`ll`, `vi`, ...) but use them, breaking IDE auto-completion and error checking
- There is no automated testing for the code. Even just compiling the code would avoid typos which have made their way into the booklet in the past, sometimes for quite a long time:
  - https://github.com/cp-sapienza/booklet/commit/600063ee56863ca8de06fed874d013e1620e0ef6 (almost 6 months)
  - https://github.com/cp-sapienza/booklet/commit/4d6827b5cf6b9793c6c99404dc728aa738edd181

  And better testing would help avoid bugs like:
  - https://github.com/cp-sapienza/booklet/commit/8b9faa5de42d87967336816ec8bf1faf21196939
  - the currently broken kmp implementation
 
This PR tries to address the problem, by adding support for preprocessing snippets before including them in the pdf via the `\snippet` command, which replaces `\lstinputlisting`. Processing is delegated to `utils/get_snippet.py`, which in this example implementation removes includes and trims the file down. Additionally, `source/common.h` contains the common definitions so that snippets can have access to them in order to make IDEs work.

A nice effect of processing `#include`s is that it allows for some automated testing (the snippets can now be compiled since they have all the definitions they need) and it can allow for dependency detection to automatically annotate code with `Requires \verb|X|`, which is still manual. _Note that this is all potential future functionality._

As a usage example, I modified `source/template.cpp` and `source/egcd.cpp` to reflect how this change impacts the code.

Open to any feedback before we set on a solution