### PR TITLE
Prefer using __int128 in mod_mul

### DIFF
--- a/content/maths.tex
+++ b/content/maths.tex
@@ -5,7 +5,7 @@
 \subsection{Modular multiplication}
 \bigo{logN} Time
 
-Computes $(a * b)$\:\%\:mod without overflow.
+Computes $(a * b)$\:\%\:mod without overflow. Use the second version only if \texttt{\_\_int128} isn't supported, it's much slower.
 \snippet{source/mod_mul.h}
 
 

--- a/source/mod_mul.h
+++ b/source/mod_mul.h
@@ -2,6 +2,11 @@
 #include "common.h"
 
 ll mod_mul(ll a, ll b, ll mod) {
+    return (ll)((__int128)a * b % mod);
+}
+
+// SLOW version if __int128 isn't supported
+ll mod_mul(ll a, ll b, ll mod) {
 	ll res = 0;
 	for (a %= mod, b %= mod; b != 0; b >>= 1, a = (a << 1) % mod)
 		if (b & 1) res = (res + a) % mod;


### PR DESCRIPTION
The `logN` loop is significantly slower than a 128 bit multiplication, so we should prefer the second option if `__int128` is supported (which is almost always the case). I don't have extensive benchmarks, but got a ~15x speedup on https://atcoder.jp/contests/abc284/tasks/abc284_d, where I was trying to factorize a 64bit number