### PR TITLE
Fix linear recurrences

### DIFF
--- a/source/linear_recurrences.h
+++ b/source/linear_recurrences.h
@@ -15,8 +15,12 @@ ll linear_recurrence(const vector<ll>& a, const vector<ll>& b, const vector<ll>&
 			m[k+i][k+j] = (m[k+i-1][k+j-1] + m[k+i-1][k+j]) % mod;
 	}
 
-	vector<ll> xx(k+h, 1);
+	vector<ll> xx(k+h);
 	for(int i = 0; i < k; i++) xx[i] = x[i];
+	if(h > 0) {
+        xx[k] = 1;
+	    for(int i = 1; i < h; i++) xx[k+i] = (xx[k+i-1] * k) % mod;
+    }
 
 	auto res = mat_mul(mat_pow(m, n, mod), xx, mod);
 	return (res[0] % mod + mod) % mod;

--- a/source/linear_recurrences.h
+++ b/source/linear_recurrences.h
@@ -3,7 +3,7 @@
 #include "matrix_mult_pow.h"
 
 ll linear_recurrence(const vector<ll>& a, const vector<ll>& b, const vector<ll>& x, ll n, ll mod) {
-	int k = a.size(), h = b.size();
+	int k = ssize(a), h = ssize(b);
 	Matrix m(k+h, vector<ll>(k+h, 0));
 
 	for(int i = 0; i < k-1; i++) m[i][i+1] = 1;

--- a/source/linear_recurrences.h
+++ b/source/linear_recurrences.h
@@ -17,10 +17,8 @@ ll linear_recurrence(const vector<ll>& a, const vector<ll>& b, const vector<ll>&
 
 	vector<ll> xx(k+h);
 	for(int i = 0; i < k; i++) xx[i] = x[i];
-	if(h > 0) {
-        xx[k] = 1;
-	    for(int i = 1; i < h; i++) xx[k+i] = (xx[k+i-1] * k) % mod;
-    }
+	if(h > 0) xx[k] = 1;
+	for(int i = 1; i < h; i++) xx[k+i] = (xx[k+i-1] * k) % mod;
 
 	auto res = mat_mul(mat_pow(m, n, mod), xx, mod);
 	return (res[0] % mod + mod) % mod;


### PR DESCRIPTION
The code was wrongly initializing the powers of the index to 1, while they should have been the powers of `k`. Tested on https://codeforces.com/gym/102644/problem/G, and stress tested against the `O(N)` implementaton with the following:

<details>
<summary> Stress testing code </summary>

```cpp
    srand(42);
    for(int _ = 0; _ < 10000; _++)
    {
        ll k = rand() % 20 + 1;
        ll h = rand() % 20 + 1;
        ll n = rand() % 10000 + k;
        vll a(k), b(h), c(k);
        for(auto& x : a) x = rand() % mod;
        for(auto& x : b) x = rand() % mod;
        for(auto& x : c) x = rand() % mod;

        ll res = linear_recurrence(a, b, c, n, mod);

        vll v(n + 1);
        for(int i = 0; i < k; i++) v[i] = c[i];
        for(int i = k; i <= n; i++)
        {
            v[i] = 0;
            for(int j = 0; j < k; j++)
                v[i] = (v[i] + v[i-j-1] * a[j]) % mod;
            ll p = 1;
            for(int j = 0; j < h; j++)
            {
                v[i] = (v[i] + p * b[j]) % mod;
                p = (p * i) % mod;
            }
        }

        cout << res << ' ' << v[n] << '\n';
        assert(res == v[n]);
    }
```
</details>