### PR TITLE
fixed a sign in ccw_rotation + readability

### DIFF
--- a/source/point.h
+++ b/source/point.h
@@ -50,4 +50,6 @@ struct Point {
 // clockwise rotation: use -theta, center = c
 Point<ld> ccw_rotation(ld theta, const Point<ld> p, const Point<ld> c = Point<ld>(0, 0)){
 	ld rad = deg_to_rad(theta);
-	return Point(cosl(rad) * (p.x - c.x) - sinl(rad) * (p.y - c.y) + c.x, sinl(rad) * (p.x - c.x) - cosl(rad) * (p.y - c.y) + c.y); }
+	return Point(
+		cosl(rad) * (p.x - c.x) - sinl(rad) * (p.y - c.y) + c.x, 
+		sinl(rad) * (p.x - c.x) + cosl(rad) * (p.y - c.y) + c.y); }


### PR DESCRIPTION
This doesn't change the line count in the pdf. The important change is the sign of cosl(rad) in the y 