### PR TITLE
Uprev upload-artifact to v4

### DIFF
--- a/.github/workflows/check-pr.yml
+++ b/.github/workflows/check-pr.yml
@@ -28,7 +28,7 @@ jobs:
           args: -interaction=nonstopmode -shell-escape
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: main.pdf
           path: main.pdf


### PR DESCRIPTION
## What's in this PR

Uprev `upload-artifacts` GitHub action to v4 since the v3 is about to be deprecated. No [breaking changes](https://github.com/actions/upload-artifact?tab=readme-ov-file#breaking-changes) in our case, so nothing special to change.

## Testing

The action is working as expected:

![immagine](https://github.com/user-attachments/assets/5e8c2cc9-5fab-4fa1-aff1-f4731e412db8)